### PR TITLE
Updated compilation options to enable installing on linux.

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -1,2 +1,2 @@
 CXX_STD = CXX11
-PKG_CXXFLAGS = -I../inst/include
+PKG_CXXFLAGS = -I../inst/include -std=c++11


### PR DESCRIPTION
Enforced the -std=c++11 flag to ensure installation on linux machines.

previously, the following error would be encountered:

```
> install.packages("~/rEDM/", repos=NULL, type="source")
Installing package into ‘/net/home/store/home/kkamala/R/x86_64-pc-linux-gnu-library/3.0’
(as ‘lib’ is unspecified)
* installing *source* package ‘rEDM’ ...
** libs
g++ -I/usr/share/R/include -DNDEBUG   -I"/net/home/store/home/kkamala/R/x86_64-pc-linux-gnu-library/3.0/Rcpp/include"  -I../inst/include -fpic  -O3 -pipe  -g  -c RcppExports.cpp -o RcppExports.o
g++ -I/usr/share/R/include -DNDEBUG   -I"/net/home/store/home/kkamala/R/x86_64-pc-linux-gnu-library/3.0/Rcpp/include"  -I../inst/include -fpic  -O3 -pipe  -g  -c block_lnlp.cpp -o block_lnlp.o
In file included from /usr/include/c++/4.8/thread:35:0,
                 from forecast_machine.h:7,
                 from block_lnlp.h:6,
                 from block_lnlp.cpp:1:
/usr/include/c++/4.8/bits/c++0x_warning.h:32:2: error: #error This file requires compiler and library support for the ISO C++ 2011 standard. This support is currently experimental, and must be enabled with the -std=c++11 or -std=gnu++11 compiler options.
 #error This file requires compiler and library support for the \
  ^
In file included from block_lnlp.h:6:0,
                 from block_lnlp.cpp:1:
forecast_machine.h:56:5: error: ‘function’ in namespace ‘std’ does not name a type
     std::function<double (const vec&, const vec&)> dist_func;
     ^
block_lnlp.cpp: In member function ‘Rcpp::List BlockLNLP::get_short_smap_coefficients()’:
block_lnlp.cpp:204:14: error: ‘curr_pred’ does not name a type
     for(auto curr_pred: which_pred)
              ^
block_lnlp.cpp:208:5: error: expected ‘;’ before ‘return’
     return(wrap(short_smap_coefficients));
     ^
block_lnlp.cpp:208:5: error: expected primary-expression before ‘return’
block_lnlp.cpp:208:5: error: expected ‘;’ before ‘return’
block_lnlp.cpp:208:5: error: expected primary-expression before ‘return’
block_lnlp.cpp:208:5: error: expected ‘)’ before ‘return’
make: *** [block_lnlp.o] Error 1
ERROR: compilation failed for package ‘rEDM’
* removing ‘/net/home/store/home/kkamala/R/x86_64-pc-linux-gnu-library/3.0/rEDM’
Warning message:
In install.packages("~/rEDM/", repos = NULL, type = "source") :
  installation of package ‘/home/kkamala/rEDM/’ had non-zero exit status
```
